### PR TITLE
修复打开2个窗口的问题

### DIFF
--- a/Get-JDCookie.py
+++ b/Get-JDCookie.py
@@ -31,6 +31,12 @@ async def main():
     browser = await launch(headless=False, dumpio=True, autoClose=False,
                            args=['--no-sandbox', '--window-size=1000,800', '--disable-infobars'])   # 进入有头模式
     context = await browser.createIncognitoBrowserContext() # 隐身模式
+
+    # 关闭默认打开的第一个标签页
+    pages = await browser.pages()
+    if pages:
+        await pages[0].close()
+
     page = await context.newPage()           # 打开新的标签页
     await page.setViewport({'width': 1000, 'height': 800})      # 页面大小一致
     await page.goto('https://home.m.jd.com/myJd/home.action',{'timeout': 1000*60}) # 访问主页、增加超时解决Navigation Timeout Exceeded: 30000 ms exceeded报错


### PR DESCRIPTION
## 概述 
Issue: #7 

## 解决方法

添加了关闭默认打开的第一个标签页的步骤。

具体更改如下：
- 调用`browser.pages()`获取当前打开的页面列表。
- 检查列表中是否有页面（通常会有一个默认的空白页面），如果有，则关闭第一个页面。
- 接着在隐私上下文中打开新的页面进行后续操作。

感谢您考虑合并这个更改

Fixes #7 
